### PR TITLE
feat(shared): expand defaultProductsData with more sample products

### DIFF
--- a/apps/web/src/app/playground/types.ts
+++ b/apps/web/src/app/playground/types.ts
@@ -9,6 +9,12 @@ const defaultProductsData: ProductsData = {
   products: [
     { id: '1', name: 'Coffee', price: 3.5, inStock: true },
     { id: '2', name: 'Tea', price: 2.9, inStock: false },
+    { id: '3', name: 'Milk', price: 1.8, inStock: true },
+    { id: '4', name: 'Bread', price: 2.2, inStock: true },
+    { id: '5', name: 'Chocolate', price: 4.5, inStock: false },
+    { id: '6', name: 'Juice', price: 3.1, inStock: true },
+    { id: '7', name: 'Water', price: 1.0, inStock: true },
+    { id: '8', name: 'Cheese', price: 5.7, inStock: false },
   ],
 };
 


### PR DESCRIPTION
## Summary
Added more sample products to `defaultProductsData` for testing and demo purposes.

## Details
- Extended the product list from 2 to 8 items
- Included both `inStock: true` and `false` cases
- Covered a wider price range and product names

## Testing notes
1. Run `pnpm -F web dev`
2. Open http://localhost:3000/playground (or the page using `defaultProductsData`)
3. Verify the longer list of products renders correctly
4. Confirm typecheck passes: `pnpm -w run typecheck`
