### PR TITLE
feat(web): add typed env helper and runtime validation with Zod

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+text=auto eol=lf
+* text=auto eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.md text eol=lf

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+node_modules/
+.next/
+dist/
+build/
+coverage/
+test-results/
+apps/web/.next/
+apps/web/out/
+apps/web/test-results/
+packages/**/dist/
+pnpm-lock.yaml
+.pnpm-store/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "prettier.useEditorConfig": true,
+  "files.eol": "\n",
+
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
+
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -39,8 +39,13 @@ const resolvers = {
     products: () => db,
   },
   Mutation: {
-    addProduct: (_: unknown, args: { name: string; price: number; inStock: boolean}) => {
-      const item: Product = { id: String(Date.now()), name: args.name, price: args.price, inStock: args.inStock };
+    addProduct: (_: unknown, args: { name: string; price: number; inStock: boolean }) => {
+      const item: Product = {
+        id: String(Date.now()),
+        name: args.name,
+        price: args.price,
+        inStock: args.inStock,
+      };
       db.push(item);
       return item;
     },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,17 +13,18 @@
   "dependencies": {
     "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.55.0",
+    "@ts-fullstack-learning/shared": "workspace:*",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "typescript": "^5",
-    "@ts-fullstack-learning/shared": "workspace:*"
+    "typescript": "^5"
   }
 }

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 export default function Error({
   error,
@@ -10,7 +10,7 @@ export default function Error({
   return (
     <main style={{ padding: 24 }}>
       <h1>Something went wrong</h1>
-      <p style={{ color: "#b00" }}>{error.message}</p>
+      <p style={{ color: '#b00' }}>{error.message}</p>
       <button onClick={() => reset()} style={{ marginTop: 12 }}>
         Try again
       </button>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,7 +6,12 @@ import { z } from 'zod';
 
 const PRODUCTS_QUERY = /* GraphQL */ `
   query Products {
-    products { id name price inStock }
+    products {
+      id
+      name
+      price
+      inStock
+    }
   }
 `;
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,39 +1,69 @@
 // SSR page: fetch products from GraphQL API and render a simple list.
-import type { Product } from "@ts-fullstack-learning/shared";
+import type { Product } from '@ts-fullstack-learning/shared';
 import { ProductsList } from './_components/ProductsList';
-const GRAPHQL_URL = process.env.GRAPHQL_URL ?? 'http://localhost:4000/graphql';
-const PRODUCTS_QUERY = /* GraphQL */ 'query Products { products { id name price inStock} }';
+import { getEnv } from '../lib/env';
+import { z } from 'zod';
 
-type ProductDTO = Pick<Product, "id" | "name" | "price" | "inStock">;
+const PRODUCTS_QUERY = /* GraphQL */ `
+  query Products {
+    products { id name price inStock }
+  }
+`;
 
-// Create a currency formatter once (server-side safe).
+type ProductDTO = Pick<Product, 'id' | 'name' | 'price' | 'inStock'>;
 
+// --- Zod schemas ---
+const GraphQLErrorSchema = z.object({
+  message: z.string(),
+  path: z.array(z.union([z.string(), z.number()])).optional(),
+  extensions: z.record(z.string(), z.any()).optional(),
+});
+
+const ProductDtoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  price: z.number(),
+  inStock: z.boolean(),
+});
+
+const ProductsResponseSchema = z.object({
+  data: z
+    .object({
+      products: z.array(ProductDtoSchema),
+    })
+    .optional(),
+  errors: z.array(GraphQLErrorSchema).optional(),
+});
+
+// --- Data fetch ---
 async function fetchProducts(): Promise<ProductDTO[]> {
-  const res = await fetch(GRAPHQL_URL , {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      query: PRODUCTS_QUERY,
-    }),
-    cache: "no-store", // see fresh data each request
+  const { GRAPHQL_URL } = getEnv();
+
+  const res = await fetch(GRAPHQL_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: PRODUCTS_QUERY }),
+    cache: 'no-store',
   });
 
   if (!res.ok) {
     throw new Error(`Failed to fetch products: HTTP ${res.status}`);
   }
 
-  const json: {
-    data?: { products?: ProductDTO[] };
-    errors?: Array<{ message: string }>;
-  } = await res.json();
-
-  if (json.errors?.length) {
-    throw new Error(`GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  const json = await res.json();
+  const parsed = ProductsResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(`Invalid GraphQL shape: ${parsed.error.message}`);
+  }
+  if (parsed.data.errors?.length) {
+    const msgs = parsed.data.errors.map((e) => e.message).join('; ');
+    throw new Error(`GraphQL error: ${msgs}`);
   }
 
-  return json.data?.products ?? [];
+  return parsed.data.data?.products ?? [];
 }
 
+// --- Page (SSR) ---
 export default async function Home() {
   const products = await fetchProducts();
 

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  GRAPHQL_URL: z.string().url(),
+});
+
+export function getEnv() {
+  const parsed = EnvSchema.safeParse({
+    GRAPHQL_URL: process.env.GRAPHQL_URL ?? 'http://localhost:4000/graphql',
+  });
+  if (!parsed.success) {
+    throw new Error(`Invalid env: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -3481,6 +3484,12 @@ packages:
       }
     engines: { node: '>=10' }
 
+  zod@4.1.11:
+    resolution:
+      {
+        integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==,
+      }
+
 snapshots:
   '@apollo/cache-control-types@1.0.3(graphql@16.11.0)':
     dependencies:
@@ -5708,3 +5717,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.11: {}


### PR DESCRIPTION
Summary

Introduced a typed env helper for GRAPHQL_URL and added runtime validation of GraphQL responses using Zod. Applied Prettier formatting to updated files.

Details

Added apps/web/src/lib/env.ts with Zod schema for env variables

Replaced hardcoded GRAPHQL_URL with getEnv()

Created Zod schemas for ProductDTO and GraphQL error shape

Validated GraphQL response in apps/web/src/app/page.tsx

Applied Prettier auto-formatting for consistency