### PR TITLE
feat(web): add product creation flow with GraphQL mutation

### DIFF
--- a/apps/web/src/app/actions/addProduct.ts
+++ b/apps/web/src/app/actions/addProduct.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { GraphQLClient } from 'graphql-request';
+import { getEnv } from '../lib/env';
+import { AddProductDocument, type AddProductMutationVariables } from '../graphql/generated/graphql';
+
+export async function addProductAction(input: AddProductMutationVariables) {
+  const { GRAPHQL_URL } = getEnv();
+  const client = new GraphQLClient(GRAPHQL_URL);
+  await client.request(AddProductDocument, input);
+}

--- a/apps/web/src/app/actions/addProduct.ts
+++ b/apps/web/src/app/actions/addProduct.ts
@@ -1,8 +1,8 @@
 'use server';
 
 import { GraphQLClient } from 'graphql-request';
-import { getEnv } from '../lib/env';
-import { AddProductDocument, type AddProductMutationVariables } from '../graphql/generated/graphql';
+import { getEnv } from '../../lib/env'; 
+import { AddProductDocument, type AddProductMutationVariables } from '../../graphql/generated/graphql';
 
 export async function addProductAction(input: AddProductMutationVariables) {
   const { GRAPHQL_URL } = getEnv();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,8 @@ import { ProductsList } from './_components/ProductsList';
 import { GraphQLClient } from 'graphql-request';
 import { getEnv } from '../lib/env';
 import { ProductsDocument, type ProductsQuery } from '../graphql/generated/graphql';
+import Link from 'next/link';
+
 
 // --- Data fetch ---
 async function fetchProducts() {
@@ -19,6 +21,7 @@ export default async function Home() {
   return (
     <main style={{ padding: 24 }}>
       <h1>Products</h1>
+      <Link href="/products">Add product</Link>
       <ProductsList products={products} />
     </main>
   );

--- a/apps/web/src/app/products/page.tsx
+++ b/apps/web/src/app/products/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { addProductAction } from '../actions/addProduct';
+
+export default function AddProductPage() {
+  const router = useRouter();
+  const [formState, setFormState] = useState({ name: '', price: '0', inStock: true });
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const priceNumber = Number(formState.price);
+    if (Number.isNaN(priceNumber)) {
+      setSubmitting(false);
+      return setError('Price must be a number');
+    }
+
+    try {
+      await addProductAction({
+        name: formState.name,
+        price: priceNumber,
+        inStock: formState.inStock,
+      });
+      router.push('/');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <h1>Add Product</h1>
+      <form onSubmit={onSubmit} style={{ display: 'grid', gap: 12, maxWidth: 320 }}>
+        <label>
+          Name
+          <input
+            value={formState.name}
+            onChange={(e) => setFormState((prev) => ({ ...prev, name: e.target.value }))}
+            required
+          />
+        </label>
+
+        <label>
+          Price
+          <input
+            type="number"
+            step="0.01"
+            value={formState.price}
+            onChange={(e) => setFormState((prev) => ({ ...prev, price: e.target.value }))}
+            required
+          />
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={formState.inStock}
+            onChange={(e) => setFormState((prev) => ({ ...prev, inStock: e.target.checked }))}
+          />
+          In stock
+        </label>
+
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Saving…' : 'Add product'}
+        </button>
+
+        {error && <p style={{ color: '#b00' }}>{error}</p>}
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/graphql/add-product.graphql
+++ b/apps/web/src/graphql/add-product.graphql
@@ -1,0 +1,8 @@
+mutation AddProduct($name: String!, $price: Float!, $inStock: Boolean!) {
+  addProduct(name: $name, price: $price, inStock: $inStock) {
+    id
+    name
+    price
+    inStock
+  }
+}

--- a/apps/web/src/graphql/generated/gql.ts
+++ b/apps/web/src/graphql/generated/gql.ts
@@ -14,9 +14,12 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 type Documents = {
+  'mutation AddProduct($name: String!, $price: Float!, $inStock: Boolean!) {\n  addProduct(name: $name, price: $price, inStock: $inStock) {\n    id\n    name\n    price\n    inStock\n  }\n}': typeof types.AddProductDocument;
   'query Products {\n  products {\n    id\n    name\n    price\n    inStock\n  }\n}': typeof types.ProductsDocument;
 };
 const documents: Documents = {
+  'mutation AddProduct($name: String!, $price: Float!, $inStock: Boolean!) {\n  addProduct(name: $name, price: $price, inStock: $inStock) {\n    id\n    name\n    price\n    inStock\n  }\n}':
+    types.AddProductDocument,
   'query Products {\n  products {\n    id\n    name\n    price\n    inStock\n  }\n}':
     types.ProductsDocument,
 };
@@ -35,6 +38,12 @@ const documents: Documents = {
  */
 export function gql(source: string): unknown;
 
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(
+  source: 'mutation AddProduct($name: String!, $price: Float!, $inStock: Boolean!) {\n  addProduct(name: $name, price: $price, inStock: $inStock) {\n    id\n    name\n    price\n    inStock\n  }\n}',
+): (typeof documents)['mutation AddProduct($name: String!, $price: Float!, $inStock: Boolean!) {\n  addProduct(name: $name, price: $price, inStock: $inStock) {\n    id\n    name\n    price\n    inStock\n  }\n}'];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/web/src/graphql/generated/graphql.ts
+++ b/apps/web/src/graphql/generated/graphql.ts
@@ -45,6 +45,17 @@ export type Query = {
   products: Array<Product>;
 };
 
+export type AddProductMutationVariables = Exact<{
+  name: Scalars['String']['input'];
+  price: Scalars['Float']['input'];
+  inStock: Scalars['Boolean']['input'];
+}>;
+
+export type AddProductMutation = {
+  __typename?: 'Mutation';
+  addProduct: { __typename?: 'Product'; id: string; name: string; price: number; inStock: boolean };
+};
+
 export type ProductsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type ProductsQuery = {
@@ -58,6 +69,77 @@ export type ProductsQuery = {
   }>;
 };
 
+export const AddProductDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'AddProduct' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'name' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'price' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Float' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'inStock' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Boolean' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'addProduct' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'name' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'name' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'price' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'price' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'inStock' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'inStock' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'price' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'inStock' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AddProductMutation, AddProductMutationVariables>;
 export const ProductsDocument = {
   kind: 'Document',
   definitions: [


### PR DESCRIPTION
## Summary
- add addProduct GraphQL document and codegen artifacts
- introduce server action and client form to create products
- link from home page to the creation form

## Testing
- pnpm -w run typecheck
- pnpm run dev:api
- pnpm run dev:web → /products form submits and new product appears on /

## Checklist
- [x] Codegen regenerates without warnings
- [x] addProduct mutation reachable via server action
- [x] Products list reflects new items after submission
